### PR TITLE
Settings: fix custom SIM name lost on reboot

### DIFF
--- a/src/com/android/settings/sim/MultiSimEnablerPreference.java
+++ b/src/com/android/settings/sim/MultiSimEnablerPreference.java
@@ -199,7 +199,7 @@ public class MultiSimEnablerPreference extends SwitchPreference implements
             public void onClick(DialogInterface dialog, int whichButton) {
                 mSir.setDisplayName(nameText.getText());
                 mSubscriptionManager.setDisplayName(mSir.getDisplayName().toString(),
-                        mSir.getSubscriptionId());
+                        mSir.getSubscriptionId(), SubscriptionManager.NAME_SOURCE_USER_INPUT);
 
                 final int tintSelected = tintSpinner.getSelectedItemPosition();
                 int subscriptionId = mSir.getSubscriptionId();


### PR DESCRIPTION
NAME_SOURCE_USER_INPUT should be set or the value won't
be saved in the database

Change-Id: I007eba76af5cb5a37988413a0d551eab60a9d4ca